### PR TITLE
P1: API - posts - pagination + limits

### DIFF
--- a/lib/supabase/getArtistPosts.ts
+++ b/lib/supabase/getArtistPosts.ts
@@ -4,19 +4,49 @@ import getPostsByIds from "./getPostsByIds";
 import enrichPostsWithPlatform from "./enrichPostsWithPlatform";
 import { Post, SocialPost } from "../../types/agent";
 
+interface PaginationMetadata {
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
 interface GetArtistPostsResponse {
   status: string;
   posts: Post[];
+  pagination: PaginationMetadata;
+}
+
+interface PaginationOptions {
+  limit?: number;
+  page?: number;
 }
 
 /**
  * Gets all posts for an artist account across all social platforms
  * @param artistAccountId The artist account ID to get posts for
- * @returns Object containing status and array of posts
+ * @param options Pagination options (limit and page)
+ * @returns Object containing status, array of posts, and pagination metadata
  */
 export const getArtistPosts = async (
-  artistAccountId: string
+  artistAccountId: string,
+  options: PaginationOptions = {}
 ): Promise<GetArtistPostsResponse> => {
+  const { limit = 20, page = 1 } = options;
+
+  const createEmptyPagination = (): PaginationMetadata => ({
+    total: 0,
+    page,
+    limit,
+    hasMore: false,
+  });
+
+  const createErrorResponse = (status: string): GetArtistPostsResponse => ({
+    status,
+    posts: [],
+    pagination: createEmptyPagination(),
+  });
+
   try {
     const { status, socials } = await getAccountSocials(artistAccountId);
 
@@ -24,6 +54,7 @@ export const getArtistPosts = async (
       return {
         status: "success",
         posts: [],
+        pagination: createEmptyPagination(),
       };
     }
 
@@ -35,6 +66,7 @@ export const getArtistPosts = async (
       return {
         status: "success",
         posts: [],
+        pagination: createEmptyPagination(),
       };
     }
 
@@ -42,12 +74,19 @@ export const getArtistPosts = async (
       ...new Set(allSocialPosts.map((sp) => sp.post_id).filter(Boolean)),
     ];
 
-    const allPosts = await getPostsByIds(uniquePostIds);
+    const total = uniquePostIds.length;
+    const startIndex = (page - 1) * limit;
+    const endIndex = Math.min(startIndex + limit, total);
+    const paginatedPostIds = uniquePostIds.slice(startIndex, endIndex);
+    const hasMore = endIndex < total;
+
+    const allPosts = await getPostsByIds(paginatedPostIds);
 
     if (allPosts.length === 0) {
       return {
         status: "success",
         posts: [],
+        pagination: createEmptyPagination(),
       };
     }
 
@@ -60,13 +99,16 @@ export const getArtistPosts = async (
     return {
       status: "success",
       posts: enrichedPosts,
+      pagination: {
+        total,
+        page,
+        limit,
+        hasMore,
+      },
     };
   } catch (error) {
     console.error("[ERROR] Unexpected error in getArtistPosts:", error);
-    return {
-      status: "error",
-      posts: [],
-    };
+    return createErrorResponse("error");
   }
 };
 


### PR DESCRIPTION
    actual:
    The /api/posts endpoint currently does not support pagination and limits parameters, even though these parameters have been added to the documentation.
    required:
    Update the /api/posts endpoint to support the pagination and limits parameters as documented. This should include handling parameters such as page number, page size, and limit, ensuring that the API correctly paginates and limits the returned results.