### PR TITLE
P0: Instagram - getProfiles - remove limits

### DIFF
--- a/lib/instagram/getProfiles.ts
+++ b/lib/instagram/getProfiles.ts
@@ -16,13 +16,11 @@ export async function getProfiles(handles: string[]): Promise<{
 }> {
   const cleanHandles = handles.map((handle) => handle.replace(/^@/, ""));
 
-  // Set constants for polling
   const BASE_POLLING_INTERVAL = 5000; // 5 seconds
 
-  // Adjust polling interval based on batch size
   const pollingInterval = Math.min(
-    Math.max(BASE_POLLING_INTERVAL, cleanHandles.length * 200), // Increase interval for larger batches
-    15000 // But cap at 15 seconds
+    Math.max(BASE_POLLING_INTERVAL, cleanHandles.length * 200),
+    15000
   );
 
   console.log(
@@ -49,37 +47,28 @@ export async function getProfiles(handles: string[]): Promise<{
     while (true) {
       await new Promise((resolve) => setTimeout(resolve, pollingInterval));
 
-      // Get current status
       const { status } = await getActorStatus(runId);
       console.log(`Apify run ${runId} status: ${status}`);
 
-      // If the run has failed, break out of the loop
       if (status === "FAILED") {
         console.error(`Apify run ${runId} failed`);
         break;
       }
 
-      // If the run has succeeded, break out of the loop
       if (status === "SUCCEEDED") {
         console.log(`Apify run ${runId} completed successfully`);
         break;
       }
 
-      // Continue polling if the run is still in progress
       console.log(
         `Waiting for Apify run ${runId} to complete. Elapsed time: ${Math.round((Date.now() - startTime) / 1000)}s`
       );
     }
 
-    // Retrieve the dataset items regardless of how we exited the loop
-    console.log(`Retrieving dataset items for datasetId: ${datasetId}`);
     const datasetItems = await getDataset(datasetId);
-    console.log(`Retrieved ${datasetItems.length} dataset items`);
-
     const profiles: (Social & { postUrls?: string[] })[] = [];
     const errors: Record<string, Error> = {};
 
-    // Process the dataset items
     for (const item of datasetItems) {
       const handle = item.username || item.input?.username;
 
@@ -106,7 +95,6 @@ export async function getProfiles(handles: string[]): Promise<{
       }
     }
 
-    // Check for missing profiles and add them to errors
     for (const handle of cleanHandles) {
       if (
         !profiles.some(

--- a/lib/instagram/getProfiles.ts
+++ b/lib/instagram/getProfiles.ts
@@ -16,6 +16,19 @@ export async function getProfiles(handles: string[]): Promise<{
 }> {
   const cleanHandles = handles.map((handle) => handle.replace(/^@/, ""));
 
+  // Set constants for polling
+  const BASE_POLLING_INTERVAL = 5000; // 5 seconds
+
+  // Adjust polling interval based on batch size
+  const pollingInterval = Math.min(
+    Math.max(BASE_POLLING_INTERVAL, cleanHandles.length * 200), // Increase interval for larger batches
+    15000 // But cap at 15 seconds
+  );
+
+  console.log(
+    `Fetching profiles for ${cleanHandles.length} handles with polling interval ${pollingInterval}ms`
+  );
+
   try {
     const runInfo = await runApifyActor(
       { usernames: cleanHandles },
@@ -27,49 +40,91 @@ export async function getProfiles(handles: string[]): Promise<{
     }
 
     const { runId, datasetId } = runInfo;
+    console.log(
+      `Started Apify actor run with runId: ${runId}, datasetId: ${datasetId}`
+    );
 
-    let attempts = 0;
-    const maxAttempts = 30;
-    let progress = 0;
+    const startTime = Date.now();
 
     while (true) {
-      attempts++;
-      progress = (attempts / maxAttempts) * 100;
+      await new Promise((resolve) => setTimeout(resolve, pollingInterval));
 
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-
-      const datasetItems = await getDataset(datasetId);
-
+      // Get current status
       const { status } = await getActorStatus(runId);
+      console.log(`Apify run ${runId} status: ${status}`);
 
-      const profiles: (Social & { postUrls?: string[] })[] = [];
-      const errors: Record<string, Error> = {};
-
-      for (const item of datasetItems) {
-        const handle = item.username || item.input?.username;
-
-        if (item.error) {
-          errors[handle] = new Error(item.error);
-          continue;
-        }
-
-        const formattedAccount = getFormattedAccount([item]);
-        if (formattedAccount?.profile) {
-          profiles.push({
-            ...formattedAccount.profile,
-            postUrls: formattedAccount.postUrls || [],
-          });
-        } else {
-          errors[handle] = new Error("Failed to format profile data");
-        }
+      // If the run has failed, break out of the loop
+      if (status === "FAILED") {
+        console.error(`Apify run ${runId} failed`);
+        break;
       }
 
-      if (status === "SUCCEEDED" || attempts >= maxAttempts) {
-        return { profiles, errors };
+      // If the run has succeeded, break out of the loop
+      if (status === "SUCCEEDED") {
+        console.log(`Apify run ${runId} completed successfully`);
+        break;
+      }
+
+      // Continue polling if the run is still in progress
+      console.log(
+        `Waiting for Apify run ${runId} to complete. Elapsed time: ${Math.round((Date.now() - startTime) / 1000)}s`
+      );
+    }
+
+    // Retrieve the dataset items regardless of how we exited the loop
+    console.log(`Retrieving dataset items for datasetId: ${datasetId}`);
+    const datasetItems = await getDataset(datasetId);
+    console.log(`Retrieved ${datasetItems.length} dataset items`);
+
+    const profiles: (Social & { postUrls?: string[] })[] = [];
+    const errors: Record<string, Error> = {};
+
+    // Process the dataset items
+    for (const item of datasetItems) {
+      const handle = item.username || item.input?.username;
+
+      if (!handle) {
+        console.warn(`Missing username in dataset item:`, item);
+        continue;
+      }
+
+      if (item.error) {
+        console.error(`Error in dataset item for ${handle}: ${item.error}`);
+        errors[handle] = new Error(item.error);
+        continue;
+      }
+
+      const formattedAccount = getFormattedAccount([item]);
+      if (formattedAccount?.profile) {
+        profiles.push({
+          ...formattedAccount.profile,
+          postUrls: formattedAccount.postUrls || [],
+        });
+      } else {
+        console.error(`Failed to format profile data for ${handle}`);
+        errors[handle] = new Error("Failed to format profile data");
       }
     }
+
+    // Check for missing profiles and add them to errors
+    for (const handle of cleanHandles) {
+      if (
+        !profiles.some(
+          (p) => p.username.toLowerCase() === handle.toLowerCase()
+        ) &&
+        !errors[handle]
+      ) {
+        console.warn(`No data found for handle: ${handle}`);
+        errors[handle] = new Error("No data returned from Apify");
+      }
+    }
+
+    console.log(
+      `Processed ${profiles.length} profiles with ${Object.keys(errors).length} errors`
+    );
+    return { profiles, errors };
   } catch (error) {
-    console.error("getProfiles: Error fetching profiles", {
+    console.error("Error fetching profiles", {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });

--- a/lib/instagram/getProfiles.ts
+++ b/lib/instagram/getProfiles.ts
@@ -16,12 +16,7 @@ export async function getProfiles(handles: string[]): Promise<{
 }> {
   const cleanHandles = handles.map((handle) => handle.replace(/^@/, ""));
 
-  const BASE_POLLING_INTERVAL = 5000; // 5 seconds
-
-  const pollingInterval = Math.min(
-    Math.max(BASE_POLLING_INTERVAL, cleanHandles.length * 200),
-    15000
-  );
+  const pollingInterval = 5000;
 
   console.log(
     `Fetching profiles for ${cleanHandles.length} handles with polling interval ${pollingInterval}ms`


### PR DESCRIPTION
        actual:
        Hardcoded timeout limits in the current implementation prevent us from retrieving full profile information for all Instagram accounts when polling Apify.
        required:
        Remove the hardcoded timeout limits in the getProfiles function so that the Apify polling completes and returns complete data for all Instagram profiles.