### PR TITLE
P1: segment name generation - LangGraph + Claude 3.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # API Keys
 APIFY_TOKEN=your_apify_token
 OPENAI_API_KEY=your_openai_api_key
+ANTHROPIC_API_KEY=your_anthropic_api_key
 SPOTIFY_CLIENT_ID=your_spotify_client_id
 
 # Twitter Credentials

--- a/lib/langchain/getLangGraphCompletions.ts
+++ b/lib/langchain/getLangGraphCompletions.ts
@@ -1,0 +1,49 @@
+import { BaseMessage } from "@langchain/core/messages";
+import { initializeAgent, AgentOptions } from "./initializeAgent.js";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Gets completions using LangGraph with Claude 3.7 Sonnet
+ *
+ * @param messages - Array of messages to send to the LLM
+ * @param options - Options for the LangGraph agent
+ * @returns The LLM response content
+ */
+export async function getLangGraphCompletions(
+  messages: any[],
+  options: AgentOptions = {}
+): Promise<string> {
+  try {
+    const { agent } = initializeAgent(options);
+
+    console.log("[LangGraph] Invoking agent with messages");
+
+    const threadId = options.threadId || `segment-gen-${uuidv4()}`;
+    console.log(`[LangGraph] Using thread_id: ${threadId}`);
+
+    const result = await agent.invoke(
+      {
+        messages,
+      },
+      {
+        configurable: {
+          thread_id: threadId,
+        },
+      }
+    );
+
+    const resultMessages = result.messages as BaseMessage[];
+    const lastMessage = resultMessages[resultMessages.length - 1];
+
+    if (!lastMessage || !lastMessage.content) {
+      throw new Error("No content in LangGraph response");
+    }
+
+    return lastMessage.content as string;
+  } catch (error) {
+    console.error("[LangGraph] Error getting completions:", error);
+    throw error;
+  }
+}
+
+export default getLangGraphCompletions;

--- a/lib/langchain/initializeAgent.ts
+++ b/lib/langchain/initializeAgent.ts
@@ -1,0 +1,45 @@
+import { ChatAnthropic } from "@langchain/anthropic";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { MemorySaver } from "@langchain/langgraph";
+
+const AI_MODEL = "claude-3-7-sonnet-latest";
+
+export interface AgentOptions {
+  tools?: any[];
+  messageModifier?: string;
+  threadId?: string;
+  maxTokens?: number;
+}
+
+export interface AgentResult {
+  agent: ReturnType<typeof createReactAgent>;
+  memory: MemorySaver;
+}
+
+/**
+ * Initializes a LangGraph agent with Claude 3.7 Sonnet
+ *
+ * @param options - Options for configuring the agent
+ * @returns The initialized agent and memory
+ */
+export const initializeAgent = (options: AgentOptions = {}): AgentResult => {
+  console.log("[LangGraph] Initializing agent with Claude 3.7 Sonnet");
+
+  const llm = new ChatAnthropic({
+    modelName: AI_MODEL,
+    maxTokens: options.maxTokens || 4096,
+  });
+
+  const memory = new MemorySaver();
+
+  const agent = createReactAgent({
+    llm,
+    tools: options.tools || [],
+    messageModifier: options.messageModifier || "",
+    checkpointSaver: memory,
+  });
+
+  return { agent, memory };
+};
+
+export default initializeAgent;

--- a/lib/segments/generateSegmentNames.ts
+++ b/lib/segments/generateSegmentNames.ts
@@ -1,29 +1,70 @@
-import getChatCompletions from "../getChatCompletions.js";
+import { getLangGraphCompletions } from "../langchain/getLangGraphCompletions.js";
 import { instructions } from "../instructions.js";
 import { Comment } from "../types/segment.types.js";
+import { v4 as uuidv4 } from "uuid";
 
+/**
+ * Generates segment names from comments using LangGraph with Claude 3.7 Sonnet
+ *
+ * @param comments - Array of comments or comment texts
+ * @param maxSegments - Maximum number of segments to generate (default: 5)
+ * @returns Array of segment names
+ */
 export const generateSegmentNames = async (
-  comments: string[] | Comment[]
+  comments: string[] | Comment[],
+  maxSegments = 5
 ): Promise<string[]> => {
-  const promptWithContext =
-    typeof comments[0] === "string"
-      ? `Comments: ${JSON.stringify(comments)}`
-      : `Comments with social data: ${JSON.stringify(comments)}`;
+  console.log(
+    `[Segments] Generating segment names for ${comments.length} comments`
+  );
 
-  const response = await getChatCompletions([
-    {
-      role: "system",
-      content: instructions.generate_segments,
-    },
+  // Generate a unique thread_id for this segment generation request
+  const threadId = `segment-gen-${uuidv4()}`;
+
+  // Construct the prompt for the LLM - only user message
+  const messages = [
     {
       role: "user",
-      content: promptWithContext,
+      content: `Generate ${maxSegments} segment names for these comments: ${JSON.stringify(comments)}`,
     },
-  ]);
+  ];
 
-  if (!response) {
-    throw new Error("Failed to generate segment names");
+  try {
+    console.log("[Segments] Calling LangGraph for segment name generation");
+
+    // Use LangGraph for completions - pass system message as messageModifier and include threadId
+    const response = await getLangGraphCompletions(messages, {
+      messageModifier: instructions.generate_segments,
+      maxTokens: 4096,
+      threadId,
+    });
+
+    if (!response) {
+      throw new Error("No response from LLM");
+    }
+
+    console.log(
+      "[Segments] Received response from LangGraph, parsing segment names"
+    );
+
+    // Parse the response to extract segment names
+    let segmentNames: string[] = [];
+    try {
+      // Clean the response and parse JSON
+      const cleanedResponse = response.replace(/```json\n?|```/g, "").trim();
+      segmentNames = JSON.parse(cleanedResponse);
+
+      console.log(
+        `[Segments] Successfully parsed ${segmentNames.length} segment names`
+      );
+    } catch (error) {
+      console.error("[Segments] Error parsing segment names:", error);
+      throw new Error("Failed to parse segment names from LLM response");
+    }
+
+    return segmentNames;
+  } catch (error) {
+    console.error("[Segments] Error generating segment names:", error);
+    throw error;
   }
-
-  return JSON.parse(response.replace(/```json\n?|```/g, ""));
 };

--- a/lib/segments/generateSegmentNames.ts
+++ b/lib/segments/generateSegmentNames.ts
@@ -7,32 +7,27 @@ import { v4 as uuidv4 } from "uuid";
  * Generates segment names from comments using LangGraph with Claude 3.7 Sonnet
  *
  * @param comments - Array of comments or comment texts
- * @param maxSegments - Maximum number of segments to generate (default: 5)
  * @returns Array of segment names
  */
 export const generateSegmentNames = async (
-  comments: string[] | Comment[],
-  maxSegments = 5
+  comments: string[] | Comment[]
 ): Promise<string[]> => {
   console.log(
     `[Segments] Generating segment names for ${comments.length} comments`
   );
 
-  // Generate a unique thread_id for this segment generation request
   const threadId = `segment-gen-${uuidv4()}`;
 
-  // Construct the prompt for the LLM - only user message
   const messages = [
     {
       role: "user",
-      content: `Generate ${maxSegments} segment names for these comments: ${JSON.stringify(comments)}`,
+      content: `Generate segment names for these comments: ${JSON.stringify(comments)}`,
     },
   ];
 
   try {
     console.log("[Segments] Calling LangGraph for segment name generation");
 
-    // Use LangGraph for completions - pass system message as messageModifier and include threadId
     const response = await getLangGraphCompletions(messages, {
       messageModifier: instructions.generate_segments,
       maxTokens: 4096,
@@ -47,10 +42,8 @@ export const generateSegmentNames = async (
       "[Segments] Received response from LangGraph, parsing segment names"
     );
 
-    // Parse the response to extract segment names
     let segmentNames: string[] = [];
     try {
-      // Clean the response and parse JSON
       const cleanedResponse = response.replace(/```json\n?|```/g, "").trim();
       segmentNames = JSON.parse(cleanedResponse);
 

--- a/lib/segments/generateSegments.ts
+++ b/lib/segments/generateSegments.ts
@@ -16,7 +16,7 @@ export const generateSegments = async (
   artistAccountId: string
 ): Promise<GenerateSegmentsResult> => {
   try {
-    const batchSize = 500;
+    const batchSize = 1000;
     const commentBatches: Comment[][] = [];
 
     for (let i = 0; i < comments.length; i += batchSize) {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,15 @@
   "dependencies": {
     "@ardrive/turbo-sdk": "^1.2.0",
     "@browserbasehq/stagehand": "^1.10.1",
+    "@langchain/anthropic": "^0.3.15",
+    "@langchain/core": "^0.3.42",
+    "@langchain/langgraph": "^0.2.55",
     "@playwright/test": "^1.49.1",
     "@stackso/js-core": "^0.5.10",
     "@supabase/supabase-js": "^2.47.9",
     "@tavily/core": "^0.0.2",
     "@types/cheerio": "^0.22.35",
+    "@types/uuid": "^10.0.0",
     "agent-twitter-client": "^0.0.16",
     "apify-client": "^2.10.0",
     "arweave": "^1.14.4",
@@ -38,7 +42,7 @@
     "prettier": "^3.4.1",
     "socket.io": "^4.8.1",
     "ts-node": "^10.9.2",
-    "uuid": "^11.0.4",
+    "uuid": "^11.0.5",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ importers:
       '@browserbasehq/stagehand':
         specifier: ^1.10.1
         version: 1.12.0(@playwright/test@1.50.1)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@16.4.7)(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@langchain/anthropic':
+        specifier: ^0.3.15
+        version: 0.3.15(@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)))
+      '@langchain/core':
+        specifier: ^0.3.42
+        version: 0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+      '@langchain/langgraph':
+        specifier: ^0.2.55
+        version: 0.2.55(@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)))
       '@playwright/test':
         specifier: ^1.49.1
         version: 1.50.1
@@ -29,6 +38,9 @@ importers:
       '@types/cheerio':
         specifier: ^0.22.35
         version: 0.22.35
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       agent-twitter-client:
         specifier: ^0.0.16
         version: 0.0.16
@@ -75,7 +87,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.13.1)(typescript@5.7.3)
       uuid:
-        specifier: ^11.0.4
+        specifier: ^11.0.5
         version: 11.0.5
       zod:
         specifier: ^3.24.1
@@ -120,6 +132,9 @@ packages:
 
   '@anthropic-ai/sdk@0.27.3':
     resolution: {integrity: sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==}
+
+  '@anthropic-ai/sdk@0.37.0':
+    resolution: {integrity: sha512-tHjX2YbkUBwEgg0JZU3EFSSAQPoK4qQR/NFYa8Vtzd5UAyXzZksCw2In69Rml4R/TyHPBfRYaLK35XiOe33pjw==}
 
   '@apify/consts@2.37.0':
     resolution: {integrity: sha512-GCK7wZcUPnHMUpoxd1tgbDgojdgcdxpnaF8UX5h5/hq5ZPdlik7EP2CkU6MpRfYxYl8T5LOsANUJvdB6bGthKA==}
@@ -308,6 +323,9 @@ packages:
       dotenv: ^16.4.5
       openai: ^4.62.1
       zod: ^3.23.8
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -571,6 +589,39 @@ packages:
   '@kyvejs/types@1.4.1':
     resolution: {integrity: sha512-35Pv9yqcFQIdYQrDeoMfVJzMNr26fKJE5cCEF4d7lHiMJDLVaJ4M8x9cPzAfis7Rd5sfZV9Hm3giB5pBbaZljA==}
 
+  '@langchain/anthropic@0.3.15':
+    resolution: {integrity: sha512-Ar2viYcZ64idgV7EtCBCb36tIkNtPAhQRxSaMTWPHGspFgMfvwRoleVri9e90sCpjpS9xhlHsIQ0LlUS/Atsrw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.21 <0.4.0'
+
+  '@langchain/core@0.3.42':
+    resolution: {integrity: sha512-pT/jC5lqWK3YGDq8dQwgKoa6anqAhMtG1x5JbnrOj9NdaLeBbCKBDQ+/Ykzk3nZ8o+0UMsaXNZo7IVL83VVjHg==}
+    engines: {node: '>=18'}
+
+  '@langchain/langgraph-checkpoint@0.0.16':
+    resolution: {integrity: sha512-B50l7w9o9353drHsdsD01vhQrCJw0eqvYeXid7oKeoj1Yye+qY90r97xuhiflaYCZHM5VEo2oaizs8oknerZsQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+
+  '@langchain/langgraph-sdk@0.0.54':
+    resolution: {integrity: sha512-1mloRjOfiA+dB/pMHeUbjP6rxGo0QgH6QWpR9VNRq/qmeJFDlLqNiuXV/ZPENbZzlM42qufkyNjy5HVFdjOKRg==}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+
+  '@langchain/langgraph@0.2.55':
+    resolution: {integrity: sha512-Lcm8r6UCBtZjXRCoO68DR/0cVLg+gZDfcH1DWR+72UyYTwVgE2bO49IFXwiD2mL+pR8A/3bzAPebJEd38zXGyw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0'
+
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
@@ -777,6 +828,9 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
@@ -810,6 +864,9 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/send@0.17.4':
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
 
@@ -821,6 +878,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
@@ -1217,6 +1277,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  console-table-printer@2.12.1:
+    resolution: {integrity: sha512-wKGOQRRvdnd89pCeH96e2Fn4wkbenSP6LMHfjfyNLMbGuHEFbMqQNuxXqd0oXG9caIOQ1FTvc5Uijp9/4jujnQ==}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -1303,6 +1366,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
 
   dedent@1.5.3:
     resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
@@ -1480,6 +1547,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -1511,6 +1581,10 @@ packages:
 
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
+
+  fast-xml-parser@4.5.3:
+    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
+    hasBin: true
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -2025,6 +2099,14 @@ packages:
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
+  langsmith@0.3.13:
+    resolution: {integrity: sha512-iI5MO5FP1EFxU1jyQvB2cM4qKqXXwnsd124MKWWhBuV2O/EjdwzsyKPBVlBPFjAQbgCGtzqdJWbv9xld60hb+Q==}
+    peerDependencies:
+      openai: '*'
+    peerDependenciesMeta:
+      openai:
+        optional: true
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -2135,6 +2217,10 @@ packages:
 
   multistream@4.1.0:
     resolution: {integrity: sha512-J1XDiAmmNpRCBfIWJv+n0ymC4ABcf/Pl+5YvC5B/D2f/2+8PtHvCNxMPKiQcZyi922Hq69J2YOpb1pTywfifyw==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   nan@2.22.0:
     resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
@@ -2248,6 +2334,10 @@ packages:
       typescript:
         optional: true
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -2258,6 +2348,18 @@ packages:
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
   p-try@2.2.0:
@@ -2527,6 +2629,9 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
+  simple-wcswidth@1.0.1:
+    resolution: {integrity: sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -2595,6 +2700,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
@@ -2799,12 +2907,20 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
   uuid@11.0.5:
     resolution: {integrity: sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==}
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -2982,6 +3098,18 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@anthropic-ai/sdk@0.27.3':
+    dependencies:
+      '@types/node': 18.19.75
+      '@types/node-fetch': 2.6.12
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@anthropic-ai/sdk@0.37.0':
     dependencies:
       '@types/node': 18.19.75
       '@types/node-fetch': 2.6.12
@@ -3247,6 +3375,8 @@ snapshots:
       - bufferutil
       - encoding
       - utf-8-validate
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@colors/colors@1.6.0': {}
 
@@ -3876,6 +4006,57 @@ snapshots:
 
   '@kyvejs/types@1.4.1': {}
 
+  '@langchain/anthropic@0.3.15(@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)))':
+    dependencies:
+      '@anthropic-ai/sdk': 0.37.0
+      '@langchain/core': 0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+      fast-xml-parser: 4.5.3
+      zod: 3.24.1
+      zod-to-json-schema: 3.24.1(zod@3.24.1)
+    transitivePeerDependencies:
+      - encoding
+
+  '@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.18
+      langsmith: 0.3.13(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.24.1
+      zod-to-json-schema: 3.24.1(zod@3.24.1)
+    transitivePeerDependencies:
+      - openai
+
+  '@langchain/langgraph-checkpoint@0.0.16(@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)))':
+    dependencies:
+      '@langchain/core': 0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@0.0.54(@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)))':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+    optionalDependencies:
+      '@langchain/core': 0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+
+  '@langchain/langgraph@0.2.55(@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)))':
+    dependencies:
+      '@langchain/core': 0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+      '@langchain/langgraph-checkpoint': 0.0.16(@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)))
+      '@langchain/langgraph-sdk': 0.0.54(@langchain/core@0.3.42(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)))
+      uuid: 10.0.0
+      zod: 3.24.1
+    transitivePeerDependencies:
+      - react
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -4144,6 +4325,8 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/long@4.0.2': {}
 
   '@types/mime@1.3.5': {}
@@ -4175,6 +4358,8 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/retry@0.12.0': {}
+
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
@@ -4189,6 +4374,8 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@types/uuid@8.3.4': {}
 
@@ -4697,6 +4884,10 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  console-table-printer@2.12.1:
+    dependencies:
+      simple-wcswidth: 1.0.1
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -4790,6 +4981,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 5.5.0
+
+  decamelize@1.2.0: {}
 
   dedent@1.5.3: {}
 
@@ -4959,6 +5152,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.1: {}
 
   execa@5.1.1:
@@ -5027,6 +5222,10 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-stable-stringify@1.0.0: {}
+
+  fast-xml-parser@4.5.3:
+    dependencies:
+      strnum: 1.1.2
 
   fb-watchman@2.0.2:
     dependencies:
@@ -5735,6 +5934,18 @@ snapshots:
 
   kuler@2.0.0: {}
 
+  langsmith@0.3.13(openai@4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.12.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      semver: 7.7.1
+      uuid: 10.0.0
+    optionalDependencies:
+      openai: 4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+
   leven@3.1.0: {}
 
   libsodium-sumo@0.7.15: {}
@@ -5832,6 +6043,8 @@ snapshots:
       once: 1.4.0
       readable-stream: 3.6.2
     optional: true
+
+  mustache@4.2.0: {}
 
   nan@2.22.0: {}
 
@@ -5947,6 +6160,8 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  p-finally@1.0.0: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -5958,6 +6173,20 @@ snapshots:
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   p-try@2.2.0: {}
 
@@ -6249,6 +6478,8 @@ snapshots:
     dependencies:
       semver: 7.7.1
 
+  simple-wcswidth@1.0.1: {}
+
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -6340,6 +6571,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strnum@1.1.2: {}
 
   superstruct@2.0.2: {}
 
@@ -6508,9 +6741,13 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@10.0.0: {}
+
   uuid@11.0.5: {}
 
   uuid@8.3.2: {}
+
+  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
    actual:
    The segment name generation process is currently not using LangGraph AI agents; it uses the legacy AI implementation (e.g., via lib/getChatCompletions.ts).
    required:
    Create a new library getLangGraphCompletions.ts that wraps LangGraph functionality.
    Update the lib/segments/generateSegmentNames.ts file to use the new getLangGraphCompletions library instead of the legacy getChatCompletions.ts.
    Keep changes minimal.
    Reference the implementation from the front-end web repository, for example: