### PR TITLE
P1: API - storePosts in AgentService

### DIFF
--- a/controllers/GlobalController.ts
+++ b/controllers/GlobalController.ts
@@ -275,7 +275,14 @@ export const get_account_socials = async (req: Request, res: Response) => {
 export const get_posts = async (req: Request, res: Response) => {
   const { artist_account_id, limit = 20, page = 1 } = req.query;
 
+  console.log("[DEBUG] /api/posts request params:", {
+    artist_account_id,
+    limit,
+    page,
+  });
+
   if (!artist_account_id) {
+    console.log("[ERROR] Missing artist_account_id parameter");
     return res.status(400).json({
       status: "error",
       message: "Missing required parameter: artist_account_id",
@@ -285,18 +292,40 @@ export const get_posts = async (req: Request, res: Response) => {
   const parsedLimit = Math.min(Number(limit) || 20, 100);
   const parsedPage = Math.max(Number(page) || 1, 1);
 
+  console.log("[DEBUG] Parsed pagination params:", {
+    parsedLimit,
+    parsedPage,
+  });
+
   try {
+    console.log(
+      "[DEBUG] Calling getArtistPosts for artist_account_id:",
+      artist_account_id
+    );
     const result = await getArtistPosts(artist_account_id as string, {
       limit: parsedLimit,
       page: parsedPage,
     });
 
     if (result.status === "error") {
+      console.log("[ERROR] getArtistPosts returned error status");
       return res.status(500).json({
         status: "error",
         message: "Failed to fetch posts",
       });
     }
+
+    console.log("[DEBUG] getArtistPosts response:", {
+      status: result.status,
+      postCount: result.posts.length,
+      pagination: {
+        total: result.pagination.total,
+        page: result.pagination.page,
+        limit: result.pagination.limit,
+        totalPages:
+          Math.ceil(result.pagination.total / result.pagination.limit) || 1,
+      },
+    });
 
     return res.status(200).json({
       status: "success",

--- a/controllers/PilotController.ts
+++ b/controllers/PilotController.ts
@@ -241,7 +241,7 @@ export class PilotController {
         });
 
         // Create social record first
-        const cleanHandle = handle.replace("@", "");
+        const cleanHandle = handle.replaceAll("@", "");
         console.log("[DEBUG] Processing platform:", {
           platform,
           handle,

--- a/lib/supabase/getPostsByIds.ts
+++ b/lib/supabase/getPostsByIds.ts
@@ -7,7 +7,13 @@ import type { Post } from "../../types/agent";
  * @returns Array of posts
  */
 export const getPostsByIds = async (postIds: string[]): Promise<Post[]> => {
+  console.log("[DEBUG] getPostsByIds called with:", {
+    postIdsCount: postIds.length,
+    postIds,
+  });
+
   if (!postIds.length) {
+    console.log("[DEBUG] No post IDs provided, returning empty array");
     return [];
   }
 
@@ -17,22 +23,54 @@ export const getPostsByIds = async (postIds: string[]): Promise<Post[]> => {
     postIdChunks.push(postIds.slice(i, i + chunkSize));
   }
 
+  console.log("[DEBUG] Split post IDs into chunks:", {
+    totalChunks: postIdChunks.length,
+    chunkSize,
+  });
+
   let allPosts: Post[] = [];
   for (const chunk of postIdChunks) {
+    console.log("[DEBUG] Processing post ID chunk:", {
+      chunkSize: chunk.length,
+      chunkIds: chunk,
+    });
+
     const { data: chunkPosts, error: chunkError } = await supabase
       .from("posts")
       .select("*")
       .in("id", chunk);
 
     if (chunkError) {
-      console.error("[ERROR] Error fetching posts chunk:", chunkError);
+      console.error("[ERROR] Error fetching posts chunk:", {
+        error: chunkError,
+        chunk,
+      });
       continue;
     }
 
     if (chunkPosts?.length) {
+      console.log("[DEBUG] Found posts in chunk:", {
+        requestedCount: chunk.length,
+        foundCount: chunkPosts.length,
+        missingCount: chunk.length - chunkPosts.length,
+        missingIds: chunk.filter(
+          (id) => !chunkPosts.find((post) => post.id === id)
+        ),
+      });
       allPosts = allPosts.concat(chunkPosts as Post[]);
+    } else {
+      console.log("[DEBUG] No posts found in chunk:", {
+        chunkSize: chunk.length,
+        chunkIds: chunk,
+      });
     }
   }
+
+  console.log("[DEBUG] getPostsByIds complete:", {
+    requestedPostsCount: postIds.length,
+    foundPostsCount: allPosts.length,
+    missingPostsCount: postIds.length - allPosts.length,
+  });
 
   return allPosts;
 };

--- a/lib/supabase/getSocialPostsByIds.ts
+++ b/lib/supabase/getSocialPostsByIds.ts
@@ -13,7 +13,13 @@ interface SocialPost {
 export const getSocialPostsByIds = async (
   socialIds: string[]
 ): Promise<SocialPost[]> => {
+  console.log("[DEBUG] getSocialPostsByIds called with:", {
+    socialIdsCount: socialIds.length,
+    socialIds,
+  });
+
   if (!socialIds.length) {
+    console.log("[DEBUG] No social IDs provided, returning empty array");
     return [];
   }
 
@@ -23,14 +29,31 @@ export const getSocialPostsByIds = async (
     socialIdChunks.push(socialIds.slice(i, i + socialIdChunkSize));
   }
 
+  console.log("[DEBUG] Split social IDs into chunks:", {
+    totalChunks: socialIdChunks.length,
+    chunkSize: socialIdChunkSize,
+  });
+
   let allSocialPosts: SocialPost[] = [];
 
   for (const socialIdChunk of socialIdChunks) {
+    console.log("[DEBUG] Processing social ID chunk:", {
+      chunkSize: socialIdChunk.length,
+      chunkIds: socialIdChunk,
+    });
+
     let page = 0;
     const pageSize = 1000;
     let hasMorePosts = true;
 
     while (hasMorePosts) {
+      console.log("[DEBUG] Fetching page of social posts:", {
+        page,
+        pageSize,
+        rangeStart: page * pageSize,
+        rangeEnd: (page + 1) * pageSize - 1,
+      });
+
       const { data: socialPostsPage, error: socialPostsError } = await supabase
         .from("social_posts")
         .select("post_id, social_id")
@@ -38,26 +61,43 @@ export const getSocialPostsByIds = async (
         .range(page * pageSize, (page + 1) * pageSize - 1);
 
       if (socialPostsError) {
-        console.error(
-          "[ERROR] Error fetching social_posts page:",
-          socialPostsError
-        );
+        console.error("[ERROR] Error fetching social_posts page:", {
+          error: socialPostsError,
+          page,
+          socialIdChunk,
+        });
         break;
       }
 
       if (!socialPostsPage || socialPostsPage.length === 0) {
+        console.log("[DEBUG] No more posts found for current chunk");
         hasMorePosts = false;
       } else {
+        console.log("[DEBUG] Found posts in current page:", {
+          postsCount: socialPostsPage.length,
+          firstFewPosts: socialPostsPage.slice(0, 5),
+        });
+
         allSocialPosts = allSocialPosts.concat(socialPostsPage);
 
         if (socialPostsPage.length < pageSize) {
+          console.log("[DEBUG] Page not full, no more posts to fetch");
           hasMorePosts = false;
         } else {
+          console.log("[DEBUG] Page full, fetching next page");
           page++;
         }
       }
     }
   }
+
+  console.log("[DEBUG] getSocialPostsByIds complete:", {
+    totalPostsFound: allSocialPosts.length,
+    uniqueSocialIds: [...new Set(allSocialPosts.map((sp) => sp.social_id))]
+      .length,
+    uniquePostIds: [...new Set(allSocialPosts.map((sp) => sp.post_id))].length,
+  });
+
   return allSocialPosts;
 };
 

--- a/lib/types/agent.types.ts
+++ b/lib/types/agent.types.ts
@@ -43,19 +43,23 @@ export interface AgentService {
     profile: ScrapedProfile
   ): Promise<AgentServiceResult<DbSocial>>;
 
-  // Data storage operations
-  storeComments(
-    comments: ScrapedComment[],
-    postId: string,
-    socialId: string
-  ): Promise<AgentServiceResult<DbPostComment[]>>;
+  // Artist operations
+  setupArtist(params: {
+    artistId: string;
+    social: DbSocial;
+    profile: ScrapedProfile;
+  }): Promise<AgentServiceResult<void>>;
 
-  // Composite operations
-  storeSocialData(params: StoreSocialDataParams): Promise<
-    AgentServiceResult<{
-      social: DbSocial;
-      posts: DbPost[];
-      comments: DbPostComment[];
-    }>
-  >;
+  // Post operations
+  storePosts(params: {
+    social: DbSocial;
+    posts: ScrapedPost[];
+  }): Promise<AgentServiceResult<DbPost[]>>;
+
+  // Comment operations
+  storeComments(params: {
+    social: DbSocial;
+    comments: ScrapedComment[];
+    posts: DbPost[];
+  }): Promise<AgentServiceResult<DbPostComment[]>>;
 }


### PR DESCRIPTION
    actual:
    Currently, posts are not saved to Supabase until after comments are scraped. This delays the ability to display newly scraped posts (e.g., in the /posts route) or use them as social proof during a wrapped thinking state.
    required:
    Split the existing agentService.storeSocialData method into two methods:
    agentService.storePosts – Upsert posts into the posts table and social_posts table as soon as they are scraped. setNewPosts + connectPostsToSocial
    agentService.storeComments – Upsert comments into the post_comments table, potentially at a later point in the scraping process. storeComments
    Adjust the scraping flow so that posts are saved immediately after scraping, rather than waiting until comments have also been scraped.
    This change ensures that scraped posts become available in Supabase as soon as possible, allowing the /posts route and other features to display newly discovered posts without delay.