### PR TITLE
P1: comments - no limit

### DIFF
--- a/lib/apify/pollCommentScraping.ts
+++ b/lib/apify/pollCommentScraping.ts
@@ -1,0 +1,82 @@
+import { Post } from "../../types/agent";
+import { ScrapedComment } from "../scraping/types";
+import getActorStatus from "./getActorStatus";
+import getDataset from "./getDataset";
+import { ApifyRunInfo } from "./types";
+
+const POLLING_INTERVAL = 5000; // 5 seconds
+
+interface PollCommentScrapingParams {
+  runInfo: ApifyRunInfo;
+  posts: Post[];
+  platform: string;
+  formatComments: (data: any, posts: Post[]) => ScrapedComment[];
+}
+
+/**
+ * Shared utility function to handle Apify comment scraping polling and data retrieval
+ */
+const pollCommentScraping = async ({
+  runInfo,
+  posts,
+  platform,
+  formatComments,
+}: PollCommentScrapingParams): Promise<ScrapedComment[]> => {
+  const { runId, datasetId } = runInfo;
+  const startTime = Date.now();
+  const postUrls = posts.map((post) => post.post_url);
+
+  console.log(
+    `[DEBUG] Starting ${platform} comment retrieval for ${postUrls.length} posts`
+  );
+
+  try {
+    while (true) {
+      await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL));
+
+      const { status } = await getActorStatus(runId);
+      console.log(
+        `[DEBUG] Apify run ${runId} status: ${status}. Elapsed time: ${Math.round(
+          (Date.now() - startTime) / 1000
+        )}s`
+      );
+
+      if (status === "FAILED") {
+        console.error(`[ERROR] Apify run ${runId} failed`);
+        return [];
+      }
+
+      if (status === "SUCCEEDED") {
+        console.log(`[DEBUG] Apify run ${runId} completed successfully`);
+        const data = await getDataset(datasetId);
+        if (!data?.length) {
+          console.error("[ERROR] No data returned from dataset");
+          return [];
+        }
+
+        const comments = formatComments(data, posts);
+        const totalTime = (Date.now() - startTime) / 1000;
+
+        console.log("[DEBUG] Comments scraping completed:", {
+          totalComments: comments.length,
+          averageCommentsPerPost: (comments.length / postUrls.length).toFixed(
+            1
+          ),
+          totalPosts: postUrls.length,
+          processingTimeSeconds: totalTime.toFixed(1),
+          commentsPerSecond: (comments.length / totalTime).toFixed(1),
+        });
+
+        return comments;
+      }
+    }
+  } catch (error) {
+    console.error(`[ERROR] Error in ${platform} comment polling:`, {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return [];
+  }
+};
+
+export default pollCommentScraping;

--- a/lib/apify/types.ts
+++ b/lib/apify/types.ts
@@ -1,0 +1,5 @@
+export interface ApifyRunInfo {
+  runId: string;
+  datasetId: string;
+  error?: string;
+}

--- a/lib/instagram/getPostComments.ts
+++ b/lib/instagram/getPostComments.ts
@@ -1,53 +1,29 @@
 import { Post } from "../../types/agent";
-import getActorStatus from "../apify/getActorStatus";
-import getDataset from "../apify/getDataset";
 import getFormattedComments from "./getFormattedComments";
 import startCommentsScraping from "./startCommentsScraping";
-
-const MAX_ATTEMPTS = 30;
-const POLLING_INTERVAL = 3000; // 3 seconds
+import pollCommentScraping from "../apify/pollCommentScraping";
 
 const getPostComments = async (scraping_posts: Post[]) => {
-  const postUrls = scraping_posts.map(
-    (scraping_post) => scraping_post.post_url
-  );
-
   try {
-    const runInfo = await startCommentsScraping(postUrls);
+    const runInfo = await startCommentsScraping(
+      scraping_posts.map((p) => p.post_url)
+    );
     if (!runInfo) {
-      console.error("Failed to start comments scraping");
+      console.error("[ERROR] Failed to start comments scraping");
       return [];
     }
 
-    const { runId, datasetId } = runInfo;
-    let attempts = 0;
-
-    while (attempts < MAX_ATTEMPTS) {
-      attempts++;
-      await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL));
-
-      const { status } = await getActorStatus(runId);
-
-      if (status === "FAILED") {
-        console.error("Comments scraping failed");
-        return [];
-      }
-
-      if (status === "SUCCEEDED" || attempts === MAX_ATTEMPTS) {
-        const data = await getDataset(datasetId);
-        if (!data) {
-          console.error("No data returned from dataset");
-          return [];
-        }
-
-        return getFormattedComments(data, scraping_posts);
-      }
-    }
-
-    console.error("Comments scraping timed out");
-    return [];
+    return pollCommentScraping({
+      runInfo,
+      posts: scraping_posts,
+      platform: "Instagram",
+      formatComments: getFormattedComments,
+    });
   } catch (error) {
-    console.error("Error in getPostComments:", error);
+    console.error("[ERROR] Error in getPostComments:", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
     return [];
   }
 };

--- a/lib/instagram/startCommentsScraping.ts
+++ b/lib/instagram/startCommentsScraping.ts
@@ -9,9 +9,15 @@ interface ApifyRunInfo {
 const startCommentsScraping = async (
   directUrls: Array<string>
 ): Promise<ApifyRunInfo | null> => {
+  console.log(
+    "[DEBUG] Starting Instagram comments scraping for",
+    directUrls.length,
+    "posts"
+  );
+
   const input = {
     directUrls,
-    resultsLimit: 100,
+    resultsLimit: 10000,
   };
 
   try {
@@ -21,18 +27,25 @@ const startCommentsScraping = async (
     );
 
     if (!response) {
-      console.error("Failed to start Instagram comments scraping");
+      console.error("[ERROR] Failed to start Instagram comments scraping");
       return null;
     }
 
     const { error, runId, datasetId } = response;
     if (error) {
+      console.error("[ERROR] Apify actor error:", error);
       throw new Error(error);
     }
 
+    console.log("[DEBUG] Successfully started Instagram comments scraping:", {
+      runId,
+      datasetId,
+      postCount: directUrls.length,
+    });
+
     return { runId, datasetId };
   } catch (error) {
-    console.error("Error in startCommentsScraping:", error);
+    console.error("[ERROR] Error in startCommentsScraping:", error);
     throw error;
   }
 };

--- a/lib/tiktok/startCommentsScraping.ts
+++ b/lib/tiktok/startCommentsScraping.ts
@@ -9,9 +9,15 @@ interface ApifyRunInfo {
 const startCommentsScraping = async (
   postURLs: string[]
 ): Promise<ApifyRunInfo | null> => {
+  console.log(
+    "[DEBUG] Starting TikTok comments scraping for",
+    postURLs.length,
+    "posts"
+  );
+
   const input = {
     postURLs,
-    commentsPerPost: 100,
+    commentsPerPost: 10000,
     maxRepliesPerComment: 0,
   };
 
@@ -22,18 +28,25 @@ const startCommentsScraping = async (
     );
 
     if (!response) {
-      console.error("Failed to start TikTok comments scraping");
+      console.error("[ERROR] Failed to start TikTok comments scraping");
       return null;
     }
 
     const { error, runId, datasetId } = response;
     if (error) {
+      console.error("[ERROR] Apify actor error:", error);
       throw new Error(error);
     }
 
+    console.log("[DEBUG] Successfully started TikTok comments scraping:", {
+      runId,
+      datasetId,
+      postCount: postURLs.length,
+    });
+
     return { runId, datasetId };
   } catch (error) {
-    console.error("Error in startCommentsScraping:", error);
+    console.error("[ERROR] Error in startCommentsScraping:", error);
     throw error;
   }
 };


### PR DESCRIPTION
        actual:
        Currently, there is a limit (approximately 100) on the maximum number of comments scraped for each post.
        required:
        Remove this limit so that the scraper retrieves the maximum number of comments available from every single post.