### PR TITLE
P1: Research - API - /api/spotify/search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APIFY_TOKEN=your_apify_token
 OPENAI_API_KEY=your_openai_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
 
 # Twitter Credentials
 TWITTER_USERNAME=your_twitter_username

--- a/controllers/SpotifyController.ts
+++ b/controllers/SpotifyController.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from "express";
+import getSearch from "../lib/spotify/getSearch";
+import generateAccessToken from "../lib/spotify/generateAccessToken";
+
+export const getSpotifySearchHandler = async (req: Request, res: Response) => {
+  try {
+    const { q, type, market, limit, offset } = req.query;
+    if (!q || !type) {
+      return res.status(400).json({ status: "error" });
+    }
+
+    const tokenResult = await generateAccessToken();
+    if (!tokenResult || tokenResult.error || !tokenResult.access_token) {
+      return res.status(500).json({ status: "error" });
+    }
+
+    const { data, error } = await getSearch({
+      q: String(q),
+      type: String(type),
+      market: market ? String(market) : undefined,
+      limit: limit ? String(limit) : undefined,
+      offset: offset ? String(offset) : undefined,
+      accessToken: tokenResult.access_token,
+    });
+
+    if (error) {
+      return res.status(502).json({ status: "error" });
+    }
+
+    // Build pagination object if possible
+    let pagination = undefined;
+    if (data && data[type + "s"]) {
+      const section = data[type + "s"];
+      pagination = {
+        total_count: section.total,
+        page:
+          section.offset !== undefined && section.limit
+            ? Math.floor(section.offset / section.limit) + 1
+            : 1,
+        limit: section.limit,
+        total_pages: section.limit
+          ? Math.ceil(section.total / section.limit)
+          : 1,
+      };
+    }
+
+    return res.status(200).json({
+      status: "success",
+      [type + "s"]: data ? data[type + "s"]?.items || [] : [],
+      pagination,
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ status: "error" });
+  }
+};

--- a/lib/spotify/generateAccessToken.ts
+++ b/lib/spotify/generateAccessToken.ts
@@ -1,0 +1,67 @@
+type GenerateAccessTokenResult =
+  | {
+      access_token: string;
+      token_type: string;
+      expires_in: number;
+      error: null;
+    }
+  | { access_token: null; token_type: null; expires_in: null; error: Error };
+
+const generateAccessToken = async (): Promise<GenerateAccessTokenResult> => {
+  const clientId = process.env.SPOTIFY_CLIENT_ID;
+  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    return {
+      access_token: null,
+      token_type: null,
+      expires_in: null,
+      error: new Error(
+        "Missing SPOTIFY_CLIENT_ID or SPOTIFY_CLIENT_SECRET in environment"
+      ),
+    };
+  }
+
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+    "base64"
+  );
+
+  try {
+    const response = await fetch("https://accounts.spotify.com/api/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${credentials}`,
+      },
+      body: "grant_type=client_credentials",
+    });
+
+    if (!response.ok) {
+      return {
+        access_token: null,
+        token_type: null,
+        expires_in: null,
+        error: new Error(`Spotify token request failed: ${response.status}`),
+      };
+    }
+
+    const data = await response.json();
+    return {
+      access_token: data.access_token,
+      token_type: data.token_type,
+      expires_in: data.expires_in,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      access_token: null,
+      token_type: null,
+      expires_in: null,
+      error:
+        error instanceof Error
+          ? error
+          : new Error("Unknown error generating access token"),
+    };
+  }
+};
+
+export default generateAccessToken;

--- a/lib/spotify/getSearch.ts
+++ b/lib/spotify/getSearch.ts
@@ -1,0 +1,50 @@
+type GetSearchParams = {
+  q: string;
+  type: string;
+  market?: string;
+  limit?: string | number;
+  offset?: string | number;
+  accessToken: string;
+};
+
+const getSearch = async ({
+  q,
+  type,
+  market,
+  limit,
+  offset,
+  accessToken,
+}: GetSearchParams) => {
+  try {
+    const params = new URLSearchParams({ q, type });
+    if (market) params.append("market", String(market));
+    if (limit) params.append("limit", String(limit));
+    if (offset) params.append("offset", String(offset));
+
+    const url = `https://api.spotify.com/v1/search?${params.toString()}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      return { error: new Error("Spotify API request failed"), data: null };
+    }
+
+    const data = await response.json();
+    return { data, error: null };
+  } catch (error) {
+    return {
+      data: null,
+      error:
+        error instanceof Error
+          ? error
+          : new Error("Unknown error searching Spotify"),
+    };
+  }
+};
+
+export default getSearch;

--- a/lib/spotify/searchArtist.ts
+++ b/lib/spotify/searchArtist.ts
@@ -1,26 +1,21 @@
 import { UNKNOWN_PROFILE_ERROR } from "../twitter/errors";
+import getSearch from "./getSearch";
 
 const searchArtist = async (handle: string, accessToken: string) => {
   try {
-    const response = await fetch(
-      `https://api.spotify.com/v1/search?q=${encodeURIComponent(`artist:${handle}`)}&type=artist`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    );
+    const { data, error } = await getSearch({
+      q: `artist:${handle}`,
+      type: "artist",
+      accessToken,
+    });
 
-    if (!response.ok)
+    if (error)
       return { error: new Error("Spotify api request failed"), artist: null };
 
-    const data = await response.json();
-
-    if (data.artists.items.length === 0)
+    if (!data?.artists?.items?.length)
       return { error: UNKNOWN_PROFILE_ERROR, artist: null };
-    return { artist: data.artists.items?.[0], error: null };
+
+    return { artist: data.artists.items[0], error: null };
   } catch (error) {
     console.error(error);
     return {

--- a/routes.ts
+++ b/routes.ts
@@ -10,6 +10,7 @@ import { getSegmentFansHandler } from "./controllers/SegmentFansController";
 import { getArtistSocialsHandler } from "./controllers/ArtistSocialsController";
 import { getSocialPostsHandler } from "./controllers/SocialPostsController";
 import { getPostCommentsHandler } from "./controllers/PostCommentsController";
+import { getSpotifySearchHandler } from "./controllers/SpotifyController";
 
 const routes = express.Router();
 const pilotController = new PilotController();
@@ -55,5 +56,7 @@ routes.get("/segment/fans", getSegmentFansHandler as any);
 routes.get("/artist/socials", getArtistSocialsHandler as any);
 routes.get("/social/posts", getSocialPostsHandler as any);
 routes.get("/post/comments", getPostCommentsHandler as any);
+
+routes.get("/spotify/search", getSpotifySearchHandler as any);
 
 export default routes;


### PR DESCRIPTION
    actual: missing an endpoint to display the full information returned from a spotify search for artists
    required: set up a basic endpoint at /api/spotify/search which takes the same parameters as the spotify endpoint as input and returns an array of results as outputs following other endpoints defined in the docs:
    example doc to build response object: https://recoup-docs.vercel.app/artist/socials
    spotify endpoint to call: https://api.spotify.com/v1/search
    input parameters
    q
    type
    market
    limit
    offset