### PR TITLE
P1: API - multiple types

### DIFF
--- a/controllers/SpotifyController.ts
+++ b/controllers/SpotifyController.ts
@@ -27,28 +27,7 @@ export const getSpotifySearchHandler = async (req: Request, res: Response) => {
       return res.status(502).json({ status: "error" });
     }
 
-    // Build pagination object if possible
-    let pagination = undefined;
-    if (data && data[type + "s"]) {
-      const section = data[type + "s"];
-      pagination = {
-        total_count: section.total,
-        page:
-          section.offset !== undefined && section.limit
-            ? Math.floor(section.offset / section.limit) + 1
-            : 1,
-        limit: section.limit,
-        total_pages: section.limit
-          ? Math.ceil(section.total / section.limit)
-          : 1,
-      };
-    }
-
-    return res.status(200).json({
-      status: "success",
-      [type + "s"]: data ? data[type + "s"]?.items || [] : [],
-      pagination,
-    });
+    return res.status(200).json({ status: "success", ...data });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ status: "error" });

--- a/lib/spotify/getSearch.ts
+++ b/lib/spotify/getSearch.ts
@@ -16,12 +16,15 @@ const getSearch = async ({
   accessToken,
 }: GetSearchParams) => {
   try {
+    console.log("getSearch params", { q, type, market, limit, offset });
+
     const params = new URLSearchParams({ q, type });
     if (market) params.append("market", String(market));
     if (limit) params.append("limit", String(limit));
     if (offset) params.append("offset", String(offset));
 
     const url = `https://api.spotify.com/v1/search?${params.toString()}`;
+    console.log("url", url);
     const response = await fetch(url, {
       method: "GET",
       headers: {

--- a/lib/spotify/getSearch.ts
+++ b/lib/spotify/getSearch.ts
@@ -16,15 +16,12 @@ const getSearch = async ({
   accessToken,
 }: GetSearchParams) => {
   try {
-    console.log("getSearch params", { q, type, market, limit, offset });
-
     const params = new URLSearchParams({ q, type });
     if (market) params.append("market", String(market));
     if (limit) params.append("limit", String(limit));
     if (offset) params.append("offset", String(offset));
 
     const url = `https://api.spotify.com/v1/search?${params.toString()}`;
-    console.log("url", url);
     const response = await fetch(url, {
       method: "GET",
       headers: {


### PR DESCRIPTION
    actual: if I pass comma sparated types, the results are incorrect
    required: remove the custom pagination object, return the raw response, and allow comma separated types