### PR TITLE
Update Instagram API for webhooks support

### DIFF
--- a/.cursor/rules/scratchpad.mdc
+++ b/.cursor/rules/scratchpad.mdc
@@ -82,3 +82,58 @@ You should use the [scratchpad.md](mdc:scratchpad.md) file as a Scratchpad to or
 Also update the progress of the task in the Scratchpad when you finish a subtask.
 Especially when you finished a milestone, it will help to improve your depth of task accomplishment to use the Scratchpad to reflect and plan.
 The goal is to help you maintain a big picture as well as the progress of the task. Always refer to the Scratchpad when you plan the next step.
+
+# Current Task: Add Webhooks Parameter Support for Instagram API Endpoints
+
+## Task Description
+Update Instagram API endpoints (`instagram/profiles` and `instagram/comments`) and the underlying `runApifyActor` function to accept and pass webhooks parameter to Apify API.
+
+## Requirements
+- [ ] Update `/api/instagram/profiles` to accept webhooks param from request.query
+- [ ] Update `/api/instagram/comments` to accept webhooks param from request.query  
+- [ ] Update `lib/apify/runApifyActor.ts` to pass webhooks param to Apify API
+- [ ] Webhooks param should be passed to `https://api.apify.com/v2/acts/${actorId}/runs?token=${APIFY_TOKEN}`
+- [ ] Follow Apify webhooks documentation format
+
+## Progress
+- [X] Explore current codebase structure
+- [X] Locate Instagram API endpoints
+- [X] Locate runApifyActor function
+- [X] Update runApifyActor to accept webhooks parameter
+- [X] Update Instagram profiles endpoint
+- [X] Update Instagram comments endpoint
+- [X] Test implementation
+- [X] Verify no breaking changes for other runApifyActor usages
+
+## Summary of Changes Made
+
+### 1. Updated `lib/apify/runApifyActor.ts`
+- Added optional `webhooks?: string` parameter to function signature
+- Modified URL construction to include webhooks parameter when provided
+- Used `encodeURIComponent()` to properly encode the webhooks value
+- Maintained backward compatibility with existing callers
+
+### 2. Updated `controllers/InstagramController.ts`
+- Modified `getInstagramProfilesHandler` to extract `webhooks` from `req.query`
+- Modified `getInstagramCommentsHandler` to extract `webhooks` from `req.query`
+- Both handlers now pass webhooks parameter to `runApifyActor`
+- Maintained all existing functionality and error handling
+
+### 3. Backward Compatibility
+- All existing calls to `runApifyActor` continue to work without modification
+- The webhooks parameter is optional, so no breaking changes were introduced
+- Verified that 6 other files using `runApifyActor` remain unaffected
+
+## API Usage Examples
+
+### Instagram Profiles with Webhooks
+```
+GET /instagram/profiles?handles=@username&webhooks=BASE64_ENCODED_WEBHOOKS_JSON
+```
+
+### Instagram Comments with Webhooks  
+```
+GET /instagram/comments?postUrls=["url1","url2"]&webhooks=BASE64_ENCODED_WEBHOOKS_JSON
+```
+
+The implementation follows the Apify API documentation for ad-hoc webhooks by passing the webhooks parameter as a query parameter to the actor run API endpoint.

--- a/controllers/InstagramController.ts
+++ b/controllers/InstagramController.ts
@@ -6,7 +6,7 @@ export const getInstagramProfilesHandler = async (
   res: Response
 ) => {
   try {
-    const { handles } = req.query;
+    const { handles, webhooks } = req.query;
 
     if (!handles) {
       return res.status(400).json({
@@ -28,7 +28,8 @@ export const getInstagramProfilesHandler = async (
 
     const runInfo = await runApifyActor(
       { usernames: cleanHandles },
-      "apify~instagram-profile-scraper"
+      "apify~instagram-profile-scraper",
+      webhooks as string
     );
 
     if (!runInfo) {
@@ -54,7 +55,7 @@ export const getInstagramCommentsHandler = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { postUrls } = req.query;
+    const { postUrls, webhooks } = req.query;
 
     if (!postUrls || !Array.isArray(postUrls) || postUrls.length === 0) {
       res.status(400).json({
@@ -70,7 +71,8 @@ export const getInstagramCommentsHandler = async (
 
     const response = await runApifyActor(
       input,
-      "apify~instagram-comment-scraper"
+      "apify~instagram-comment-scraper",
+      webhooks as string
     );
 
     if (!response) {

--- a/lib/apify/runApifyActor.ts
+++ b/lib/apify/runApifyActor.ts
@@ -9,19 +9,23 @@ interface ApifyRunResponse {
 
 const runApifyActor = async (
   input: any,
-  actorId: string
+  actorId: string,
+  webhooks?: string
 ): Promise<ApifyRunResponse | null> => {
   try {
-    const response = await fetch(
-      `https://api.apify.com/v2/acts/${actorId}/runs?token=${APIFY_TOKEN}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(input),
-      }
-    );
+    // Build URL with optional webhooks parameter
+    let url = `https://api.apify.com/v2/acts/${actorId}/runs?token=${APIFY_TOKEN}`;
+    if (webhooks) {
+      url += `&webhooks=${encodeURIComponent(webhooks)}`;
+    }
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(input),
+    });
 
     const data: any = await response.json();
     const error = data?.error;


### PR DESCRIPTION
Webhooks parameter support was added to the Instagram API endpoints.

*   In `lib/apify/runApifyActor.ts`, the `runApifyActor` function was updated to accept an optional `webhooks?: string` parameter.
    *   The Apify API request URL now conditionally includes `&webhooks=${encodeURIComponent(webhooks)}` when the `webhooks` parameter is provided, ensuring proper encoding.
    *   This change maintains backward compatibility for existing calls to `runApifyActor`.
*   In `controllers/InstagramController.ts`:
    *   The `getInstagramProfilesHandler` function was modified to extract `webhooks` from `req.query` and pass it to `runApifyActor`.
    *   The `getInstagramCommentsHandler` function was similarly updated to extract and pass the `webhooks` parameter.
*   The modifications enable `GET /instagram/profiles` and `GET /instagram/comments` endpoints to accept a `webhooks` query parameter, which is then forwarded to the Apify actor run, aligning with Apify's ad-hoc webhooks documentation.